### PR TITLE
[ADD] Clean `DirectionalDampedNewtonComputation`

### DIFF
--- a/docs/rtd/computations.rst
+++ b/docs/rtd/computations.rst
@@ -20,7 +20,8 @@ GGN eigenpairs (eigenvalues + eigenvector)
 .. autoclass:: vivit.DirectionalDerivativesComputation
    :members: __init__, get_extensions, get_extension_hook, get_result
 
-Newton steps
---------------
+Directionally damped Newton steps
+---------------------------------
 
-TODO
+.. autoclass:: vivit.DirectionalDampedNewtonComputation
+   :members: __init__, get_extensions, get_extension_hook, get_result

--- a/test/implementation/optim_autograd.py
+++ b/test/implementation/optim_autograd.py
@@ -2,6 +2,8 @@
 
 from test.implementation.autograd import AutogradExtensions
 
+from torch import einsum
+
 
 class AutogradOptimExtensions(AutogradExtensions):
     """Autograd implementation of optimizer functionality with similar API."""
@@ -23,3 +25,35 @@ class AutogradOptimExtensions(AutogradExtensions):
         )
 
         return gammas, lambdas
+
+    def directional_damped_newton(
+        self, param_groups, subsampling_grad=None, subsampling_ggn=None
+    ):
+
+        group_gammas, group_evecs = self.gammas_ggn(
+            param_groups,
+            ggn_subsampling=subsampling_ggn,
+            grad_subsampling=subsampling_grad,
+            directions=True,
+        )
+        group_lambdas = self.lambdas_ggn(
+            param_groups,
+            ggn_subsampling=subsampling_ggn,
+            lambda_subsampling=subsampling_ggn,
+        )
+
+        newton_steps = []
+
+        for group, gammas, lambdas, evecs in zip(
+            param_groups, group_gammas, group_lambdas, group_evecs
+        ):
+            dummy_gram_evecs = None
+            dummy_evals = None
+            deltas = group["damping"](dummy_gram_evecs, dummy_evals, gammas, lambdas)
+
+            coefficients = -gammas.mean(0) / (lambdas.mean(0) + deltas)
+            newton = einsum("id,d->i", evecs, coefficients)
+
+            newton_steps.append(newton)
+
+        return newton_steps

--- a/test/implementation/optim_backpack.py
+++ b/test/implementation/optim_backpack.py
@@ -3,8 +3,12 @@
 from test.implementation.backpack import BackpackExtensions
 
 from backpack import backpack
+from torch import cat
 
-from vivit.optim import DirectionalDerivativesComputation
+from vivit.optim import (
+    DirectionalDampedNewtonComputation,
+    DirectionalDerivativesComputation,
+)
 
 
 class BackpackOptimExtensions(BackpackExtensions):
@@ -38,3 +42,34 @@ class BackpackOptimExtensions(BackpackExtensions):
             lambdas.append(group_lambdas)
 
         return gammas, lambdas
+
+    def directional_damped_newton(
+        self,
+        param_groups,
+        subsampling_grad=None,
+        subsampling_ggn=None,
+        mc_samples_ggn=0,
+    ):
+        computations = DirectionalDampedNewtonComputation(
+            subsampling_grad=subsampling_grad,
+            subsampling_ggn=subsampling_ggn,
+            mc_samples_ggn=mc_samples_ggn,
+        )
+
+        _, _, loss = self.problem.forward_pass()
+
+        with backpack(
+            *computations.get_extensions(),
+            extension_hook=computations.get_extension_hook(param_groups),
+        ):
+            loss.backward()
+
+        newton_steps = []
+
+        for group in param_groups:
+            group_newton_step = computations.get_result(group)
+            # flatten and concatenate over parameters in group
+            group_newton_step = cat([n.flatten() for n in group_newton_step])
+            newton_steps.append(group_newton_step)
+
+        return newton_steps

--- a/test/optim/settings.py
+++ b/test/optim/settings.py
@@ -35,7 +35,7 @@ def make_criterion(k, must_exceed=1e-5):
             shift = 0
             candidates = evals
         else:
-            shift = num_evals - 1 - k
+            shift = num_evals - k
             candidates = evals[shift:]
 
         return [idx + shift for idx, ev in enumerate(candidates) if ev > must_exceed]

--- a/test/optim/test_directional_damped_newton.py
+++ b/test/optim/test_directional_damped_newton.py
@@ -5,6 +5,8 @@ from test.implementation.optim_backpack import BackpackOptimExtensions
 from test.optim.settings import (
     CRITERIA,
     CRITERIA_IDS,
+    DAMPING_IDS,
+    DAMPINGS,
     IDS_REDUCTION_MEAN,
     PARAM_BLOCKS_FN,
     PARAM_BLOCKS_FN_IDS,
@@ -19,23 +21,14 @@ from test.utils import check_sizes_and_values
 from typing import Callable, List, Union
 
 from pytest import mark
-from torch import Tensor, ones
-
-
-def damping(evals, evecs, gammas, lambdas):
-    K = gammas.shape[1]
-    return ones(K, dtype=gammas.dtype, device=gammas.device)
-
-
-DAMPING = [damping]
-DAMPING_IDS = ["damping=1"]
+from torch import Tensor
 
 
 @mark.parametrize("param_groups_fn", PARAM_BLOCKS_FN, ids=PARAM_BLOCKS_FN_IDS)
 @mark.parametrize("subsampling_ggn", SUBSAMPLINGS_GGN, ids=SUBSAMPLINGS_GGN_IDS)
 @mark.parametrize("subsampling_grad", SUBSAMPLINGS_GRAD, ids=SUBSAMPLINGS_GRAD_IDS)
 @mark.parametrize("criterion", CRITERIA, ids=CRITERIA_IDS)
-@mark.parametrize("damping", DAMPING, ids=DAMPING_IDS)
+@mark.parametrize("damping", DAMPINGS, ids=DAMPING_IDS)
 @mark.parametrize("problem", PROBLEMS_REDUCTION_MEAN, ids=IDS_REDUCTION_MEAN)
 def test_directional_derivatives(
     problem: ExtensionsTestProblem,

--- a/test/optim/test_directional_damped_newton.py
+++ b/test/optim/test_directional_damped_newton.py
@@ -1,0 +1,64 @@
+"""Test ``vivit.optim.directional_damped_newton``."""
+
+from test.implementation.optim_autograd import AutogradOptimExtensions
+from test.implementation.optim_backpack import BackpackOptimExtensions
+from test.optim.settings import (
+    CRITERIA,
+    CRITERIA_IDS,
+    IDS_REDUCTION_MEAN,
+    PARAM_BLOCKS_FN,
+    PARAM_BLOCKS_FN_IDS,
+    PROBLEMS_REDUCTION_MEAN,
+    SUBSAMPLINGS_GGN,
+    SUBSAMPLINGS_GGN_IDS,
+    SUBSAMPLINGS_GRAD,
+    SUBSAMPLINGS_GRAD_IDS,
+)
+from test.problem import ExtensionsTestProblem
+from test.utils import check_sizes_and_values
+from typing import Callable, List, Union
+
+from pytest import mark
+from torch import Tensor, ones
+
+
+def damping(evals, evecs, gammas, lambdas):
+    K = gammas.shape[1]
+    return ones(K, dtype=gammas.dtype, device=gammas.device)
+
+
+DAMPING = [damping]
+DAMPING_IDS = ["damping=1"]
+
+
+@mark.parametrize("param_groups_fn", PARAM_BLOCKS_FN, ids=PARAM_BLOCKS_FN_IDS)
+@mark.parametrize("subsampling_ggn", SUBSAMPLINGS_GGN, ids=SUBSAMPLINGS_GGN_IDS)
+@mark.parametrize("subsampling_grad", SUBSAMPLINGS_GRAD, ids=SUBSAMPLINGS_GRAD_IDS)
+@mark.parametrize("criterion", CRITERIA, ids=CRITERIA_IDS)
+@mark.parametrize("damping", DAMPING, ids=DAMPING_IDS)
+@mark.parametrize("problem", PROBLEMS_REDUCTION_MEAN, ids=IDS_REDUCTION_MEAN)
+def test_directional_derivatives(
+    problem: ExtensionsTestProblem,
+    criterion: Callable[[Tensor], List[int]],
+    subsampling_grad: Union[List[int], None],
+    subsampling_ggn: Union[List[int], None],
+    param_groups_fn: Callable,
+    damping: Callable,
+):
+    problem.set_up()
+
+    param_groups = param_groups_fn(problem.model.named_parameters(), criterion)
+    for group in param_groups:
+        group["damping"] = damping
+
+    ag_newton = AutogradOptimExtensions(problem).directional_damped_newton(
+        param_groups, subsampling_grad=subsampling_grad, subsampling_ggn=subsampling_ggn
+    )
+
+    bp_newton = BackpackOptimExtensions(problem).directional_damped_newton(
+        param_groups, subsampling_grad=subsampling_grad, subsampling_ggn=subsampling_ggn
+    )
+
+    check_sizes_and_values(ag_newton, bp_newton, rtol=1e-5, atol=1e-5)
+
+    problem.tear_down()

--- a/test/optim/test_directional_damped_newton.py
+++ b/test/optim/test_directional_damped_newton.py
@@ -36,8 +36,25 @@ def test_directional_derivatives(
     subsampling_grad: Union[List[int], None],
     subsampling_ggn: Union[List[int], None],
     param_groups_fn: Callable,
-    damping: Callable,
+    damping: Callable[[Tensor, Tensor, Tensor, Tensor], Tensor],
 ):
+    """Compare damped Newton steps.
+
+    Args:
+        problem: Test case.
+        criterion: Filter function to select directions from eigenvalues.
+        subsampling_grad: Indices of samples used for gradient sub-sampling.
+            ``None`` (equivalent to ``list(range(batch_size))``) uses all mini-batch
+            samples to compute directional gradients . Defaults to ``None`` (no
+            gradient sub-sampling).
+        subsampling_ggn: Indices of samples used for GGN curvature sub-sampling.
+            ``None`` (equivalent to ``list(range(batch_size))``) uses all mini-batch
+            samples to compute directions and directional curvatures. Defaults to
+            ``None`` (no curvature sub-sampling).
+        param_groups_fn: Function that creates the `param_groups` from the model's
+            named parameters and ``criterion``.
+        damping: Function that generates the directional dampings.
+    """
     problem.set_up()
 
     param_groups = param_groups_fn(problem.model.named_parameters(), criterion)

--- a/vivit/__init__.py
+++ b/vivit/__init__.py
@@ -4,6 +4,7 @@
 from vivit import extensions
 from vivit.linalg.eigh import EighComputation
 from vivit.linalg.eigvalsh import EigvalshComputation
+from vivit.optim.directional_damped_newton import DirectionalDampedNewtonComputation
 from vivit.optim.directional_derivatives import DirectionalDerivativesComputation
 
 __all__ = [
@@ -12,4 +13,5 @@ __all__ = [
     "EigvalshComputation",
     "EighComputation",
     "DirectionalDerivativesComputation",
+    "DirectionalDampedNewtonComputation",
 ]

--- a/vivit/optim/__init__.py
+++ b/vivit/optim/__init__.py
@@ -1,7 +1,9 @@
 """Optimization methods using low-rank representations of the GGN/Fisher."""
 
+from vivit.optim.directional_damped_newton import DirectionalDampedNewtonComputation
 from vivit.optim.directional_derivatives import DirectionalDerivativesComputation
 
 __all__ = [
     "DirectionalDerivativesComputation",
+    "DirectionalDampedNewtonComputation",
 ]

--- a/vivit/optim/directional_damped_newton.py
+++ b/vivit/optim/directional_damped_newton.py
@@ -9,7 +9,6 @@ from torch import Tensor, einsum
 from torch.nn import Module
 
 from vivit.linalg.utils import get_hook_store_batch_size
-from vivit.optim.directional_derivatives import DirectionalDerivativesComputation
 from vivit.optim.utils import get_sqrt_ggn_extension
 from vivit.utils import delete_savefield
 from vivit.utils.checks import (

--- a/vivit/optim/directional_damped_newton.py
+++ b/vivit/optim/directional_damped_newton.py
@@ -1,0 +1,238 @@
+"""Contains a class that interfaces with BackPACK to compute damped Newton steps."""
+
+import math
+from typing import Callable, Dict, List, Optional, Tuple
+
+from backpack.extensions import BatchGrad, SqrtGGNExact, SqrtGGNMC
+from backpack.extensions.backprop_extension import BackpropExtension
+from torch import Tensor, einsum
+from torch.nn import Module
+
+from vivit.linalg.utils import get_hook_store_batch_size
+from vivit.optim.directional_derivatives import DirectionalDerivativesComputation
+from vivit.optim.utils import get_sqrt_ggn_extension
+from vivit.utils import delete_savefield
+from vivit.utils.checks import (
+    check_key_exists,
+    check_subsampling_unique,
+    check_unique_params,
+)
+from vivit.utils.gram import partial_contract, reshape_as_square
+from vivit.utils.hooks import ParameterGroupsHook
+
+
+class DirectionalDampedNewtonComputation:
+    """Interfaces with BackPACK to compute directionally damped Newton steps."""
+
+    def __init__(
+        self,
+        subsampling_grad: Optional[List[int]] = None,
+        subsampling_ggn: Optional[List[int]] = None,
+        mc_samples_ggn: Optional[int] = 0,
+        verbose: Optional[bool] = False,
+    ):
+        check_subsampling_unique(subsampling_grad)
+        check_subsampling_unique(subsampling_ggn)
+
+        self._mc_samples_ggn = mc_samples_ggn
+
+        if self._mc_samples_ggn != 0:
+            assert mc_samples_ggn == 1
+            self._extension_cls_ggn = SqrtGGNMC
+        else:
+            self._extension_cls_ggn = SqrtGGNExact
+
+        self._extension_cls_grad = BatchGrad
+        self._savefield_grad = self._extension_cls_grad().savefield
+        self._subsampling_grad = subsampling_grad
+
+        self._savefield_ggn = self._extension_cls_ggn().savefield
+        self._subsampling_ggn = subsampling_ggn
+
+        self._verbose = verbose
+
+        # filled via side effects during update step computation, keys are group ids
+        self._gammas = {}
+        self._lambdas = {}
+        self._batch_size = {}
+        self._newton_steps: Dict[int, Tuple[Tensor]] = {}
+
+    def get_result(self, group: Dict) -> Tuple[Tensor]:
+        group_id = id(group)
+        try:
+            return self._newton_steps[group_id]
+        except KeyError as e:
+            raise KeyError("No results available for this group") from e
+
+    def get_extensions(self) -> List[BackpropExtension]:
+        return [
+            self._extension_cls_grad(subsampling=self._subsampling_grad),
+            get_sqrt_ggn_extension(
+                subsampling=self._subsampling_ggn, mc_samples=self._mc_samples_ggn
+            ),
+        ]
+
+    def get_extension_hook(self, param_groups: List[Dict]) -> Callable[[Module], None]:
+        self._check_param_groups(param_groups)
+        hook_store_batch_size = get_hook_store_batch_size(
+            param_groups, self._batch_size, verbose=self._verbose
+        )
+
+        param_computation = lambda hook, param: self._param_computation(  # noqa: E731
+            hook, param, self._savefield_ggn, self._savefield_grad, self._verbose
+        )
+        group_hook = lambda hook, accumulation, group: self._group_hook(  # noqa: E731
+            hook,
+            accumulation,
+            group,
+            self._batch_size,
+            self._savefield_ggn,
+            self._newton_steps,
+            self._verbose,
+        )
+        accumulate = lambda hook, existing, update: self._accumulate(  # noqa: E731
+            hook, existing, update, self._verbose
+        )
+
+        hook = ParameterGroupsHook.from_functions(
+            param_groups, param_computation, group_hook, accumulate
+        )
+
+        def extension_hook(module: Module):
+            if self._verbose:
+                print(f"Extension hook on module {id(module)} {module}")
+            hook_store_batch_size(module)
+            hook(module)
+
+        if self._verbose:
+            print("ID map groups → params")
+            for group in param_groups:
+                print(f"{id(group)} → {[id(p) for p in group['params']]}")
+
+        return extension_hook
+
+    @staticmethod
+    def _param_computation(
+        hook: ParameterGroupsHook,
+        param: Tensor,
+        savefield_ggn: str,
+        savefield_grad: str,
+        verbose: bool,
+    ) -> Dict[str, Tensor]:
+        V = getattr(param, savefield_ggn)
+        g = getattr(param, savefield_grad)
+
+        if verbose:
+            print(f"Param {id(param)}: Compute V_t_V and V_t_g_n")
+
+        result = {
+            "V_t_V": partial_contract(V, V, start_dims=(2, 2)),
+            "V_t_g_n": partial_contract(V, g, start_dims=(2, 1)),
+        }
+
+        delete_savefield(param, savefield_grad, verbose=verbose)
+
+        return result
+
+    @staticmethod
+    def _group_hook(
+        hook: ParameterGroupsHook,
+        accumulation: Dict[str, Tensor],
+        group: Dict,
+        batch_size: Dict[int, int],
+        savefield_ggn: str,
+        newton_steps: Dict[int, Tuple[Tensor]],
+        verbose: bool,
+    ):
+        group_id = id(group)
+        N = batch_size.pop(group_id)
+        N_ggn = accumulation["V_t_V"].shape[1]
+
+        # compensate scaling from BackPACK and subsampling
+        V_correction = math.sqrt(N / N_ggn)
+        gram_mat = V_correction**2 * accumulation.pop("V_t_V")
+        C = gram_mat.shape[0]
+
+        if verbose:
+            print(f"Group {group_id}: Eigen-decompose Gram matrix")
+        evals, evecs = reshape_as_square(gram_mat).symeig(eigenvectors=True)
+
+        keep = group["criterion"](evals)
+        if verbose:
+            before, after = len(evals), len(keep)
+            print(f"Group {group_id}: Filter directions ({before} → {after})")
+        evals, evecs = evals[keep], evecs[:, keep]
+
+        if verbose:
+            print(f"Group {group_id}: Compute gammas")
+        # compensate scaling from BackPACK and subsampling
+        V_t_g_n = (
+            V_correction
+            * N
+            * accumulation.pop("V_t_g_n").flatten(start_dim=0, end_dim=1)
+        )
+        gammas = einsum("in,id->nd", V_t_g_n, evecs) / evals.sqrt()
+
+        if verbose:
+            print(f"Group {group_id}: Compute lambdas")
+        # compensate scaling from BackPACK and subsampling
+        V_n_T_V_e_d = math.sqrt(N_ggn) * einsum(
+            "cni,id->cnd", gram_mat.flatten(start_dim=2), evecs
+        )
+        lambdas = (V_n_T_V_e_d**2).sum(0) / evals
+
+        # compute coefficients
+        damping = group["damping"]
+        coefficients = (
+            -gammas.mean(0)
+            / (lambdas.mean(0) + damping(evals, evecs, gammas, lambdas))
+            / evals.sqrt()
+        )
+
+        # weight in Gram space, then transform to parameter space
+        print(coefficients.shape)
+        print(evecs.shape)
+        v = einsum("id,d->i", evecs, coefficients)
+
+        # Multiply by VT
+        # compensate scaling
+        v = v * V_correction
+
+        params = group["params"]
+        v = v.reshape(C, N_ggn)
+        VTv = [
+            einsum("cn,cn...->...", v, getattr(param, savefield_ggn))
+            for param in params
+        ]
+
+        # clean up V
+        for param in params:
+            delete_savefield(param, savefield_ggn, verbose=verbose)
+
+        newton_steps[group_id] = VTv
+
+    @staticmethod
+    def _accumulate(
+        hook: ParameterGroupsHook,
+        existing: Dict[str, Tensor],
+        update: Dict[str, Tensor],
+        verbose: bool,
+    ):
+        for key in existing.keys():
+            if verbose:
+                print(f"Accumulate dot product {key}")
+            existing[key].add_(update[key])
+
+        return existing
+
+    @staticmethod
+    def _check_param_groups(param_groups: List[Dict]):
+        """Check if parameter groups satisfy the required format.
+
+        Args:
+            param_groups: Parameter groups that define the GGN block structure.
+        """
+        check_key_exists(param_groups, "params")
+        check_key_exists(param_groups, "criterion")
+        check_key_exists(param_groups, "damping")
+        check_unique_params(param_groups)

--- a/vivit/optim/directional_damped_newton.py
+++ b/vivit/optim/directional_damped_newton.py
@@ -42,7 +42,6 @@ class DirectionalDampedNewtonComputation:
         mc_samples_ggn: Optional[int] = 0,
         verbose: Optional[bool] = False,
     ):
-
         """Specify GGN and gradient approximations. Use no approximations by default.
 
         Note:
@@ -166,7 +165,6 @@ class DirectionalDampedNewtonComputation:
                 - ``{'damping': lambda evals, evecs, gammas, lambdas:
                   ones_like(evals)}`` corresponds to constant damping
                   :math:`\delta_k = 1\ \forall k`.
-
 
         Returns:
             BackPACK extension hook, to compute damped Newton steps, that should be


### PR DESCRIPTION
Adds directionally damped Newton step computation with cleaned up API.

* Fixes a bug in the eigenvalue criterion in the tests. It always picked one more eigenvalue than specified.